### PR TITLE
fix CascasdeSelect functionality

### DIFF
--- a/src/UDFCheck/UDFCheckFormGUI.php
+++ b/src/UDFCheck/UDFCheckFormGUI.php
@@ -157,6 +157,9 @@ class UDFCheckFormGUI extends ilPropertyFormGUI {
 							$check_radio->addOption($check_radio_text);
 
 							foreach ($select_gui->getColumnDefinition() as $key => $name) {
+								if (is_array($name)) {
+									$name=$name["name"]." ( ".$name["default"]." ) ";
+								}
 								$text_gui = new ilTextInputGUI($name, self::F_CHECK_VALUE_MUL . $key);
 								$check_radio_text->addSubItem($text_gui);
 							}


### PR DESCRIPTION
the current versions of CascadeSelect return an array for the column definitions instead of a string. This causes htmlspechialchars to crash, which is called when constructing html fpr the form output.  This fix chacks, if the definition is an array and sets the textinput to the name of the column and the default set in "(...)". If the old version of CascadeSelect is used, the fix stay with the old behaviour.